### PR TITLE
Stopped non-humans from being added to playable_species

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -180,8 +180,9 @@ var/global/list/string_slot_flags = list(
 		S.race_key = rkey //Used in mob icon caching.
 		all_species[S.name] = S
 
-		if(!(S.spawn_flags & SPECIES_IS_RESTRICTED))
-			playable_species += S.name
+		///////// DON'T ADD ANY FURTHER PLAYABLE SPECIES
+		//if(!(S.spawn_flags & SPECIES_IS_RESTRICTED))
+		//	playable_species += S.name
 		if(S.spawn_flags & SPECIES_IS_WHITELISTED)
 			whitelisted_species += S.name
 

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -12,3 +12,4 @@ rsmr - Game Master
 ErinCrowe Game Master
 Zth - Game Master
 Kirmaster - Game Master
+Ms.Flatgub - Game Master


### PR DESCRIPTION
Quick fix to remove alternate species from being considered playable.


![](http://puu.sh/rGoOj/1492489ff6.png)
